### PR TITLE
Basic theming support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,17 @@
 *.la
 /build*/
 
+/ChangeLog
+/Makefile
+/config.h
+/config.log
+/config.status
+/libltdl/
+/libtool
+/src/.deps/
+/src/Makefile
+/src/term
+stamp-h1
 # autotools stuff
 /m4/lt*.m4
 /m4/libtool.m4

--- a/src/term.c
+++ b/src/term.c
@@ -76,7 +76,8 @@ term_config_load_theme(GKeyFile *kf, gchar *grp, TermTheme *theme)
     gdk_color_parse(val, &theme->bg);
     g_free(val);
 
-    if ((lval = g_key_file_get_string_list(kf, grp, "Palette", &len, NULL)) == NULL)
+    if ((lval = g_key_file_get_string_list(kf, grp, "Palette",
+                                           &len, NULL)) == NULL)
         return FALSE;
 
     theme->palette_size = len;
@@ -109,7 +110,7 @@ term_config_load(void)
     key_file = g_key_file_new();
     path = g_strdup_printf("%s/%s", getenv("HOME")?:"", TERM_CONFIG_PATH);
     ret = g_key_file_load_from_file(key_file,
-                                    "/home/pyr/.config/vbeterm/vbeterm.conf",
+                                    path,
                                     G_KEY_FILE_NONE,
                                     NULL);
     g_free(path);
@@ -126,7 +127,8 @@ term_config_load(void)
 
     start_group = g_key_file_get_start_group(key_file);
 
-    if ((val = g_key_file_get_string(key_file, start_group, "WordChars", NULL)) == NULL) {
+    if ((val = g_key_file_get_string(key_file, start_group,
+                                     "WordChars", NULL)) == NULL) {
         g_strlcpy(config.word_chars, TERM_WORD_CHARS, sizeof(config.word_chars));
     } else {
         g_strlcpy(config.word_chars, val, sizeof(config.word_chars));
@@ -135,36 +137,8 @@ term_config_load(void)
     if ((lval = g_key_file_get_string_list(key_file, start_group, "Themes",
                                           &list_len, NULL)) == NULL ||
         list_len <= 0) {
-        config.theme_count = 1;
-        config.theme_index = 0;
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-        gdk_color_parse("#838394949696", &config.themes[0].fg);
-        gdk_color_parse("#00002b2b3636", &config.themes[0].bg);
-        gdk_color_parse("#0f0f49499999", &config.themes[0].cursor);
-        gdk_color_parse("#070736364242", &config.themes[0].palette[0]);
-        gdk_color_parse("#dcdc32322f2f", &config.themes[0].palette[1]);
-        gdk_color_parse("#858599990000", &config.themes[0].palette[2]);
-        gdk_color_parse("#b5b589890000", &config.themes[0].palette[3]);
-        gdk_color_parse("#26268b8bd2d2", &config.themes[0].palette[4]);
-        gdk_color_parse("#d3d336368282", &config.themes[0].palette[5]);
-        gdk_color_parse("#2a2aa1a19898", &config.themes[0].palette[6]);
-        gdk_color_parse("#eeeee8e8d5d5", &config.themes[0].palette[7]);
-        gdk_color_parse("#00002b2b3636", &config.themes[0].palette[8]);
-        gdk_color_parse("#cbcb4b4b1616", &config.themes[0].palette[9]);
-        gdk_color_parse("#58586e6e7575", &config.themes[0].palette[10]);
-        gdk_color_parse("#65657b7b8383", &config.themes[0].palette[11]);
-        gdk_color_parse("#838394949696", &config.themes[0].palette[12]);
-        gdk_color_parse("#6c6c7171c4c4", &config.themes[0].palette[13]);
-        gdk_color_parse("#9393a1a1a1a1", &config.themes[0].palette[14]);
-        gdk_color_parse("#fdfdf6f6e3e3", &config.themes[0].palette[15]);
-#pragma GCC diagnostic pop
-
-        config.themes[0].bold = FALSE;
-        config.themes[0].opacity = 1.0;
-        g_strlcpy(config.themes[0].font, "Terminus 12",
-                  sizeof(config.themes[0].font));
+        config.theme_count = 0;
+        return;
     } else {
         for (i = 0; i < list_len; i++) {
             TermTheme *theme;
@@ -182,6 +156,9 @@ void
 term_theme_apply(gint index)
 {
     TermTheme *theme = &config.themes[index];
+
+    if (index >= config.theme_count)
+        return;
 
 	vte_terminal_set_scrollback_lines(VTE_TERMINAL(terminal), 0);
 	vte_terminal_set_scroll_on_output(VTE_TERMINAL(terminal),  FALSE);

--- a/src/term.c
+++ b/src/term.c
@@ -19,11 +19,15 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
 #include <vte/vte.h>
 #include <gdk/gdk.h>
 #include <gdk/gdkkeysyms-compat.h>
+#include <glib.h>
 
 GtkWidget *window, *terminal;
+TermConfig config;
 
 static void
 set_font_size(gint delta)
@@ -36,6 +40,179 @@ set_font_size(gint delta)
 	pango_font_description_set_size(descr, current + delta * PANGO_SCALE);
 	vte_terminal_set_font(VTE_TERMINAL(terminal), descr);
 	pango_font_description_free(descr);
+}
+
+static gboolean
+term_config_load_theme(GKeyFile *kf, gchar *grp, TermTheme *theme)
+{
+    gsize len;
+    gsize i;
+    gchar *val;
+    gchar **lval;
+
+    theme->opacity = g_key_file_get_double(kf, grp, "Opacity", NULL);
+    theme->bold = g_key_file_get_boolean(kf, grp, "Bold", NULL);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+    if ((val = g_key_file_get_string(kf, grp, "Cursor", NULL)) == NULL)
+        return FALSE;
+    gdk_color_parse(val, &theme->cursor);
+    g_free(val);
+
+    if ((val = g_key_file_get_string(kf, grp, "Font", NULL)) == NULL)
+        return FALSE;
+    g_strlcpy(theme->font, val, sizeof(theme->font));
+    g_free(val);
+
+    if ((val = g_key_file_get_string(kf, grp, "Foreground", NULL)) == NULL)
+        return FALSE;
+    gdk_color_parse(val, &theme->fg);
+    g_free(val);
+
+    if ((val = g_key_file_get_string(kf, grp, "Background", NULL)) == NULL)
+        return FALSE;
+    gdk_color_parse(val, &theme->bg);
+    g_free(val);
+
+    if ((lval = g_key_file_get_string_list(kf, grp, "Palette", &len, NULL)) == NULL)
+        return FALSE;
+
+    theme->palette_size = len;
+    if (len > TERM_THEME_PALETTE_MAX) {
+        g_free(lval);
+        return FALSE;
+    }
+
+    for (i = 0; i < theme->palette_size; i++) {
+        gdk_color_parse(lval[i], &theme->palette[i]);
+    }
+    g_free(lval);
+
+#pragma GCC diagnostic pop
+    return TRUE;
+}
+
+static void
+term_config_load(void)
+{
+    gchar *path;
+    GKeyFile *key_file;
+    gboolean ret;
+    gchar *start_group;
+    gchar *val;
+    gchar **lval;
+    gsize list_len;
+    gsize i;
+
+    key_file = g_key_file_new();
+    path = g_strdup_printf("%s/%s", getenv("HOME")?:"", TERM_CONFIG_PATH);
+    ret = g_key_file_load_from_file(key_file,
+                                    "/home/pyr/.config/vbeterm/vbeterm.conf",
+                                    G_KEY_FILE_NONE,
+                                    NULL);
+    g_free(path);
+
+    if (!ret) {
+        /*
+         * provide some sensible defaults
+         */
+        g_key_file_load_from_data(key_file, TERM_CONFIG_DEFAULT,
+                                  strlen(TERM_CONFIG_DEFAULT),
+                                  G_KEY_FILE_NONE,
+                                  NULL);
+    }
+
+    start_group = g_key_file_get_start_group(key_file);
+
+    if ((val = g_key_file_get_string(key_file, start_group, "WordChars", NULL)) == NULL) {
+        g_strlcpy(config.word_chars, TERM_WORD_CHARS, sizeof(config.word_chars));
+    } else {
+        g_strlcpy(config.word_chars, val, sizeof(config.word_chars));
+    }
+
+    if ((lval = g_key_file_get_string_list(key_file, start_group, "Themes",
+                                          &list_len, NULL)) == NULL ||
+        list_len <= 0) {
+        config.theme_count = 1;
+        config.theme_index = 0;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        gdk_color_parse("#838394949696", &config.themes[0].fg);
+        gdk_color_parse("#00002b2b3636", &config.themes[0].bg);
+        gdk_color_parse("#0f0f49499999", &config.themes[0].cursor);
+        gdk_color_parse("#070736364242", &config.themes[0].palette[0]);
+        gdk_color_parse("#dcdc32322f2f", &config.themes[0].palette[1]);
+        gdk_color_parse("#858599990000", &config.themes[0].palette[2]);
+        gdk_color_parse("#b5b589890000", &config.themes[0].palette[3]);
+        gdk_color_parse("#26268b8bd2d2", &config.themes[0].palette[4]);
+        gdk_color_parse("#d3d336368282", &config.themes[0].palette[5]);
+        gdk_color_parse("#2a2aa1a19898", &config.themes[0].palette[6]);
+        gdk_color_parse("#eeeee8e8d5d5", &config.themes[0].palette[7]);
+        gdk_color_parse("#00002b2b3636", &config.themes[0].palette[8]);
+        gdk_color_parse("#cbcb4b4b1616", &config.themes[0].palette[9]);
+        gdk_color_parse("#58586e6e7575", &config.themes[0].palette[10]);
+        gdk_color_parse("#65657b7b8383", &config.themes[0].palette[11]);
+        gdk_color_parse("#838394949696", &config.themes[0].palette[12]);
+        gdk_color_parse("#6c6c7171c4c4", &config.themes[0].palette[13]);
+        gdk_color_parse("#9393a1a1a1a1", &config.themes[0].palette[14]);
+        gdk_color_parse("#fdfdf6f6e3e3", &config.themes[0].palette[15]);
+#pragma GCC diagnostic pop
+
+        config.themes[0].bold = FALSE;
+        config.themes[0].opacity = 1.0;
+        g_strlcpy(config.themes[0].font, "Terminus 12",
+                  sizeof(config.themes[0].font));
+    } else {
+        for (i = 0; i < list_len; i++) {
+            TermTheme *theme;
+
+            theme = &config.themes[config.theme_count];
+            if (term_config_load_theme(key_file, lval[i], theme))
+                config.theme_count++;
+            else
+                bzero(theme, sizeof(*theme));
+        }
+    }
+}
+
+void
+term_theme_apply(gint index)
+{
+    TermTheme *theme = &config.themes[index];
+
+	vte_terminal_set_scrollback_lines(VTE_TERMINAL(terminal), 0);
+	vte_terminal_set_scroll_on_output(VTE_TERMINAL(terminal),  FALSE);
+	vte_terminal_set_scroll_on_keystroke(VTE_TERMINAL(terminal), TRUE);
+	vte_terminal_set_rewrap_on_resize(VTE_TERMINAL(terminal), TRUE);
+
+	vte_terminal_set_colors(VTE_TERMINAL(terminal), &theme->fg, &theme->bg,
+                            theme->palette, theme->palette_size);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+	vte_terminal_set_opacity(VTE_TERMINAL(terminal), theme->opacity * 65535);
+#pragma GCC diagnostic pop
+
+	vte_terminal_set_color_cursor(VTE_TERMINAL(terminal), &theme->cursor);
+	vte_terminal_set_cursor_blink_mode(VTE_TERMINAL(terminal),
+	    VTE_CURSOR_BLINK_OFF);
+	vte_terminal_set_allow_bold(VTE_TERMINAL(terminal), theme->bold);
+	vte_terminal_set_font_from_string(VTE_TERMINAL(terminal), theme->font);
+	set_font_size(0);
+
+	vte_terminal_set_audible_bell(VTE_TERMINAL(terminal), FALSE);
+	vte_terminal_set_visible_bell(VTE_TERMINAL(terminal), FALSE);
+}
+
+void
+term_theme_cycle()
+{
+    gint next_theme = (config.theme_index + 1) % config.theme_count;
+    term_theme_apply(next_theme);
+    config.theme_index = next_theme;
 }
 
 static gboolean
@@ -76,6 +253,9 @@ on_key_press(GtkWidget *terminal, GdkEventKey *event)
 		case GDK_equal:
 			set_font_size(0);
 			return TRUE;
+        case GDK_percent:
+            term_theme_cycle();
+            return TRUE;
 		}
 	}
 	return FALSE;
@@ -106,16 +286,15 @@ get_child_environment(void)
 	return result;
 }
 
-
 int
 main(int argc, char *argv[])
 {
-    GdkColor fg;
-    GdkColor bg;
-    GdkColor palette[16];
-
 	/* Initialise GTK and the widgets */
 	gtk_init(&argc, &argv);
+
+    /* load configuration */
+    bzero(&config, sizeof(config));
+    term_config_load();
 	window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 	terminal = vte_terminal_new();
 	gtk_window_set_title(GTK_WINDOW(window), PACKAGE_NAME);
@@ -134,67 +313,9 @@ main(int argc, char *argv[])
 	    G_CALLBACK(on_dpi_changed), NULL);
 
 	/* Configure terminal */
-	vte_terminal_set_word_chars(VTE_TERMINAL(terminal),
-	    TERM_WORD_CHARS);
-	vte_terminal_set_scrollback_lines(VTE_TERMINAL(terminal),
-	    0);
-	vte_terminal_set_scroll_on_output(VTE_TERMINAL(terminal),
-	    FALSE);
-	vte_terminal_set_scroll_on_keystroke(VTE_TERMINAL(terminal),
-	    TRUE);
-	vte_terminal_set_rewrap_on_resize(VTE_TERMINAL(terminal),
-	    TRUE);
+	vte_terminal_set_word_chars(VTE_TERMINAL(terminal), config.word_chars);
+    term_theme_apply(0);
 
-#define CLR_R(x)   (((x) & 0xff0000) >> 16)
-#define CLR_G(x)   (((x) & 0x00ff00) >>  8)
-#define CLR_B(x)   (((x) & 0x0000ff) >>  0)
-#define CLR_16(x)  (((x) << 8) | (x))
-#define CLR_GDK(x) (const GdkColor){ 0, CLR_16(CLR_R(x)), CLR_16(CLR_G(x)), CLR_16(CLR_B(x)) }
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    gdk_color_parse("#838394949696", &fg);
-    gdk_color_parse("#00002b2b3636", &bg);
-    gdk_color_parse("#070736364242", &palette[0]);
-    gdk_color_parse("#dcdc32322f2f", &palette[1]);
-    gdk_color_parse("#858599990000", &palette[2]);
-    gdk_color_parse("#b5b589890000", &palette[3]);
-    gdk_color_parse("#26268b8bd2d2", &palette[4]);
-    gdk_color_parse("#d3d336368282", &palette[5]);
-    gdk_color_parse("#2a2aa1a19898", &palette[6]);
-    gdk_color_parse("#eeeee8e8d5d5", &palette[7]);
-    gdk_color_parse("#00002b2b3636", &palette[8]);
-    gdk_color_parse("#cbcb4b4b1616", &palette[9]);
-    gdk_color_parse("#58586e6e7575", &palette[10]);
-    gdk_color_parse("#65657b7b8383", &palette[11]);
-    gdk_color_parse("#838394949696", &palette[12]);
-    gdk_color_parse("#6c6c7171c4c4", &palette[13]);
-    gdk_color_parse("#9393a1a1a1a1", &palette[14]);
-    gdk_color_parse("#fdfdf6f6e3e3", &palette[15]);
-#pragma GCC diagnostic pop
-	vte_terminal_set_colors(VTE_TERMINAL(terminal),
-        &fg,
-        &bg,
-        palette,
-        16);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	vte_terminal_set_opacity(VTE_TERMINAL(terminal),
-	    TERM_OPACITY * 65535);
-#pragma GCC diagnostic pop
-	vte_terminal_set_color_cursor(VTE_TERMINAL(terminal),
-	    &CLR_GDK(0x008800));
-	vte_terminal_set_cursor_blink_mode(VTE_TERMINAL(terminal),
-	    VTE_CURSOR_BLINK_OFF);
-	vte_terminal_set_allow_bold(VTE_TERMINAL(terminal),
-	    FALSE);
-	vte_terminal_set_font_from_string(VTE_TERMINAL(terminal),
-	    TERM_FONT);
-	set_font_size(0);
-
-	vte_terminal_set_audible_bell(VTE_TERMINAL(terminal),
-	    FALSE);
-	vte_terminal_set_visible_bell(VTE_TERMINAL(terminal),
-	    FALSE);
 
 	/* Start a new shell */
 	gchar **env;

--- a/src/term.c
+++ b/src/term.c
@@ -211,6 +211,9 @@ void
 term_theme_cycle()
 {
     gint next_theme = (config.theme_index + 1) % config.theme_count;
+
+    if (config.theme_count <= 0)
+        return;
     term_theme_apply(next_theme);
     config.theme_index = next_theme;
 }

--- a/src/term.c
+++ b/src/term.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <vte/vte.h>
+#include <gdk/gdk.h>
 #include <gdk/gdkkeysyms-compat.h>
 
 GtkWidget *window, *terminal;
@@ -109,6 +110,10 @@ get_child_environment(void)
 int
 main(int argc, char *argv[])
 {
+    GdkColor fg;
+    GdkColor bg;
+    GdkColor palette[16];
+
 	/* Initialise GTK and the widgets */
 	gtk_init(&argc, &argv);
 	window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
@@ -145,26 +150,32 @@ main(int argc, char *argv[])
 #define CLR_B(x)   (((x) & 0x0000ff) >>  0)
 #define CLR_16(x)  (((x) << 8) | (x))
 #define CLR_GDK(x) (const GdkColor){ 0, CLR_16(CLR_R(x)), CLR_16(CLR_G(x)), CLR_16(CLR_B(x)) }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    gdk_color_parse("#838394949696", &fg);
+    gdk_color_parse("#00002b2b3636", &bg);
+    gdk_color_parse("#070736364242", &palette[0]);
+    gdk_color_parse("#dcdc32322f2f", &palette[1]);
+    gdk_color_parse("#858599990000", &palette[2]);
+    gdk_color_parse("#b5b589890000", &palette[3]);
+    gdk_color_parse("#26268b8bd2d2", &palette[4]);
+    gdk_color_parse("#d3d336368282", &palette[5]);
+    gdk_color_parse("#2a2aa1a19898", &palette[6]);
+    gdk_color_parse("#eeeee8e8d5d5", &palette[7]);
+    gdk_color_parse("#00002b2b3636", &palette[8]);
+    gdk_color_parse("#cbcb4b4b1616", &palette[9]);
+    gdk_color_parse("#58586e6e7575", &palette[10]);
+    gdk_color_parse("#65657b7b8383", &palette[11]);
+    gdk_color_parse("#838394949696", &palette[12]);
+    gdk_color_parse("#6c6c7171c4c4", &palette[13]);
+    gdk_color_parse("#9393a1a1a1a1", &palette[14]);
+    gdk_color_parse("#fdfdf6f6e3e3", &palette[15]);
+#pragma GCC diagnostic pop
 	vte_terminal_set_colors(VTE_TERMINAL(terminal),
-	    &CLR_GDK(0xffffff),
-	    &CLR_GDK(0),
-	    (const GdkColor[]){	CLR_GDK(0x111111),
-			CLR_GDK(0xd36265),
-			CLR_GDK(0xaece91),
-			CLR_GDK(0xe7e18c),
-			CLR_GDK(0x5297cf),
-			CLR_GDK(0x963c59),
-			CLR_GDK(0x5E7175),
-			CLR_GDK(0xbebebe),
-			CLR_GDK(0x666666),
-			CLR_GDK(0xef8171),
-			CLR_GDK(0xcfefb3),
-			CLR_GDK(0xfff796),
-			CLR_GDK(0x74b8ef),
-			CLR_GDK(0xb85e7b),
-			CLR_GDK(0xA3BABF),
-			CLR_GDK(0xffffff)
- 	    }, 16);
+        &fg,
+        &bg,
+        palette,
+        16);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	vte_terminal_set_opacity(VTE_TERMINAL(terminal),
@@ -175,7 +186,7 @@ main(int argc, char *argv[])
 	vte_terminal_set_cursor_blink_mode(VTE_TERMINAL(terminal),
 	    VTE_CURSOR_BLINK_OFF);
 	vte_terminal_set_allow_bold(VTE_TERMINAL(terminal),
-	    TRUE);
+	    FALSE);
 	vte_terminal_set_font_from_string(VTE_TERMINAL(terminal),
 	    TERM_FONT);
 	set_font_size(0);

--- a/src/term.h
+++ b/src/term.h
@@ -22,9 +22,50 @@
 #  include <config.h>
 #endif
 
+#include <gdk/gdk.h>
+
 #define TERM_WORD_CHARS "-A-Za-z0-9:./?%&#_=+@~"
 #define TERM_OPACITY 1.0
-#define TERM_FONT2 "DejaVu Sans Mono for Powerline 10"
 #define TERM_FONT "Terminus 12"
+#define TERM_WORDCHARS_MAX 32
+#define TERM_THEME_NAMELEN 32
+#define TERM_THEMES_MAX 8
+#define TERM_THEME_PALETTE_MAX 16
+#define TERM_THEME_FONT_MAX 64
+#define TERM_CONFIG_PATH ".config/vbeterm/vbeterm.conf"
+#define TERM_CONFIG_DEFAULT ("[main]\n"                                 \
+                             "WordChars=-A-Za-z0-9:./?%&#_=+@~\n"       \
+                             "Themes=default\n"                         \
+                             "[default]\n"                              \
+                             "Font=DejaVu Sans Mono for Powerline 10\n" \
+                             "Opacity=0.85\n"                           \
+                             "Bold=true\n"                              \
+                             "Cursor=#008800\n"                         \
+                             "Foreground=#ffffff\n"                     \
+                             "Background=#000000\n"                     \
+                             "Palette=#111111;#d36265;#xaece91;"        \
+                             "#e7e18c;#5297cf;"                         \
+                             "#963c59;#5E7175;#bebebe;"                 \
+                             "#666666;#ef8171;#cfefb3;"                 \
+                             "#fff796;#74b8ef;#b85e7b;#A3BABF;#ffffff\n")
+
+typedef struct {
+    gchar name[TERM_THEME_NAMELEN];
+    GdkColor fg;
+    GdkColor bg;
+    GdkColor cursor;
+    gboolean bold;
+    gdouble opacity;
+    gsize palette_size;
+    GdkColor palette[TERM_THEME_PALETTE_MAX];
+    gchar font[TERM_THEME_FONT_MAX];
+} TermTheme;
+
+typedef struct {
+    gchar word_chars[TERM_WORDCHARS_MAX];
+    int theme_count;
+    int theme_index;
+    TermTheme themes[TERM_THEMES_MAX];
+} TermConfig;
 
 #endif

--- a/src/term.h
+++ b/src/term.h
@@ -23,7 +23,8 @@
 #endif
 
 #define TERM_WORD_CHARS "-A-Za-z0-9:./?%&#_=+@~"
-#define TERM_OPACITY 0.85
-#define TERM_FONT "DejaVu Sans Mono for Powerline 10"
+#define TERM_OPACITY 1.0
+#define TERM_FONT2 "DejaVu Sans Mono for Powerline 10"
+#define TERM_FONT "Terminus 12"
 
 #endif

--- a/vbeterm.conf.example
+++ b/vbeterm.conf.example
@@ -1,0 +1,21 @@
+[main]
+WordChars=-A-Za-z0-9:./?%&#_=+@~" 
+Themes=SolarizedDark;SolarizedLight
+
+[SolarizedDark]
+Font=Terminus 12
+Opacity=1.0
+Bold=false
+Cursor=#0f0f49499999
+Foreground=#838394949696
+Background=#00002b2b3636
+Palette=#070736364242;#dcdc32322f2f;#858599990000;#b5b589890000;#26268b8bd2d2;#d3d336368282;#2a2aa1a19898;#eeeee8e8d5d5;#00002b2b3636;#cbcb4b4b1616;#58586e6e7575;#65657b7b8383;#838394949696;#6c6c7171c4c4;#9393a1a1a1a1;#fdfdf6f6e3e3
+
+[SolarizedLight]
+Font=Terminus 12
+Opacity=1.0
+Bold=false
+Cursor=#586e75
+Foreground=#657b83
+Background=#fdf6e3
+Palette=#eee8d5;#dc322f;#859900;#b58900;#268bd2;#d33682;#2aa198;#073642;#fdf6e3;#cb4b16;#93a1a1;#839496;#657b83;#6c71c4;#586e75;#002b36


### PR DESCRIPTION
This allows configuration of vbeterm from a file in `$HOME/.config/vbeterm/vbeterm.conf`.
The file is a standard glib key file and allows creating up to 8 themes which can be cycled through with `C-%`.
An example configuration file with both solarized-light and solarized-dark themes is provided.

This also brings parsing of `-e` to specify comands.
